### PR TITLE
Wire up bundlePath

### DIFF
--- a/pkg/registry/bundle.go
+++ b/pkg/registry/bundle.go
@@ -28,13 +28,14 @@ func init() {
 }
 
 type Bundle struct {
-	Name       string
-	Objects    []*unstructured.Unstructured
-	Package    string
-	Channel    string
-	csv        *ClusterServiceVersion
-	crds       []*v1beta1.CustomResourceDefinition
-	cacheStale bool
+	Name        string
+	Objects     []*unstructured.Unstructured
+	Package     string
+	Channel     string
+	BundleImage string
+	csv         *ClusterServiceVersion
+	crds        []*v1beta1.CustomResourceDefinition
+	cacheStale  bool
 }
 
 func NewBundle(name, pkgName, channelName string, objs ...*unstructured.Unstructured) *Bundle {
@@ -170,12 +171,12 @@ func (b *Bundle) AllProvidedAPIsInBundle() error {
 	return nil
 }
 
-func (b *Bundle) Serialize() (csvName string, csvBytes []byte, bundleBytes []byte, err error) {
+func (b *Bundle) Serialize() (csvName, bundleImage string, csvBytes []byte, bundleBytes []byte, err error) {
 	csvCount := 0
 	for _, obj := range b.Objects {
 		objBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
 		if err != nil {
-			return "", nil, nil, err
+			return "", "", nil, nil, err
 		}
 		bundleBytes = append(bundleBytes, objBytes...)
 
@@ -183,16 +184,16 @@ func (b *Bundle) Serialize() (csvName string, csvBytes []byte, bundleBytes []byt
 			csvName = obj.GetName()
 			csvBytes, err = runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
 			if err != nil {
-				return "", nil, nil, err
+				return "", "", nil, nil, err
 			}
 			csvCount += 1
 			if csvCount > 1 {
-				return "", nil, nil, fmt.Errorf("two csvs found in one bundle")
+				return "", "", nil, nil, fmt.Errorf("two csvs found in one bundle")
 			}
 		}
 	}
 
-	return csvName, csvBytes, bundleBytes, nil
+	return csvName, b.BundleImage, csvBytes, bundleBytes, nil
 }
 
 func (b *Bundle) Images() (map[string]struct{}, error) {

--- a/pkg/sqlite/load.go
+++ b/pkg/sqlite/load.go
@@ -68,7 +68,7 @@ func (s *SQLLoader) AddOperatorBundle(bundle *registry.Bundle) error {
 	}
 	defer addImage.Close()
 
-	csvName, csvBytes, bundleBytes, err := bundle.Serialize()
+	csvName, bundleImage, csvBytes, bundleBytes, err := bundle.Serialize()
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (s *SQLLoader) AddOperatorBundle(bundle *registry.Bundle) error {
 		return fmt.Errorf("csv name not found")
 	}
 
-	if _, err := stmt.Exec(csvName, csvBytes, bundleBytes, nil); err != nil {
+	if _, err := stmt.Exec(csvName, csvBytes, bundleBytes, bundleImage); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Use the passed in image bundle to store the bundlePath in the registry
when adding via `opm add`

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
