### PR TITLE
Delete non default bundles

### DIFF
--- a/pkg/containertools/bundlereader.go
+++ b/pkg/containertools/bundlereader.go
@@ -65,7 +65,8 @@ func (b *BundleReader) GetBundle(image, outputDir string) error {
 	if err != nil {
 		return err
 	}
-// Untar theimage layer tarballs and push the bundle manifests to the output directory
+	
+	// Untar the image layer tarballs and push the bundle manifests to the output directory
 	for _, tarball := range layerTarballs {
 		f, err = os.Open(rootTarfile)
 		if err != nil {

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -8,6 +8,7 @@ type Load interface {
 	AddOperatorBundle(bundle *Bundle) error
 	AddPackageChannels(manifest PackageManifest) error
 	RmPackageName(packageName string) error
+	ClearNonDefaultBundles(packageName string) error
 }
 
 type Query interface {

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -151,6 +151,11 @@ func (i *ImageLoader) loadManifests(manifests, image string, annotationsFile *re
 		return fmt.Errorf("Error adding package %s", err)
 	}
 
+	// Finally let's delete all the old bundles
+	if err = i.store.ClearNonDefaultBundles(packageManifest.PackageName); err != nil {
+		return fmt.Errorf("Error deleting previous bundles: %s", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Add a function to the sql loader that, once the database has been
updated, deletes the bundle and csv field from all bundles that are not
the tip of the default channel of the package being updated

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
